### PR TITLE
change delay to &mut delay

### DIFF
--- a/examples/ftdi.rs
+++ b/examples/ftdi.rs
@@ -44,9 +44,9 @@ fn main() {
     let reset = hal.ad7().unwrap();
 
     log::info!("Configuring device...");
-    let mut device = ice40::Device::new(spi, ss, done, reset, DummyDelay);
+    let mut device = ice40::Device::new(spi, ss, done, reset);
     device
-        .configure(&bitstream[..])
+        .configure(&mut DummyDelay, &bitstream[..])
         .expect("Failed to configure FPGA");
     log::info!("done!");
 }

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -66,9 +66,9 @@ fn main() {
     reset.set_direction(Direction::Out).unwrap();
 
     log::info!("Configuring device...");
-    let mut device = ice40::Device::new(spi, ss, done, reset, DummyDelay);
+    let mut device = ice40::Device::new(spi, ss, done, reset);
     device
-        .configure(&bitstream[..])
+        .configure(&mut DummyDelay, &bitstream[..])
         .expect("Failed to configure FPGA");
     log::info!("done!");
 }


### PR DESCRIPTION
There was no need to consume delay.
In addition, when using this lib with anther one that also need delay and working on rp2040, it becomes difficult to use both with only one delay that is consumed by the ice40 lib.

I did found a work around with the newtype patterns
```rust
struct DelayWrapper<'a, T: DelayUs<u16>>(&'a mut T);

impl<'a, T: DelayUs<u16>> DelayUs<u16> for DelayWrapper<'a, T> {
    fn delay_us(&mut self, us: u16) {
        self.0.delay_us(us)
    }
}
```

but it will be easier to just not consume the delay  